### PR TITLE
Switch to HTTPS API URL

### DIFF
--- a/wolframalpha/__init__.py
+++ b/wolframalpha/__init__.py
@@ -77,7 +77,7 @@ class Client(object):
             input=query,
             appid=self.app_id,
         ))
-        url = 'http://api.wolframalpha.com/v2/query?' + query
+        url = 'https://api.wolframalpha.com/v2/query?' + query
         resp = urllib.request.urlopen(url)
         assert resp.headers.get_content_type() == 'text/xml'
         assert resp.headers.get_param('charset') == 'utf-8'


### PR DESCRIPTION
This alphabet soup closes #5.

Successfully tested by installing over the stable release from my fork. The precise command I used, for reproducibility before merging:

````bash
sudo pip install --upgrade git+git://github.com/dgw/wolframalpha.git@https-api#egg=wolframalpha
````

I then restarted the IRC bot importing this module to be sure it was reloaded and ran a few test calls:

````IRC
<~dgw> ;wa 2+2
  • dgw waits
<&Kaede> [W|A] Result: 4
<~dgw> ;wa airspeed velocity of an unladen swallow
<&Kaede> [W|A] Result: 25 mph  (miles per hour)(asked, but not answered, about
         a general swallow in the 1975 film Monty Python and the Holy Grail)
````